### PR TITLE
Updates to relay-api-types

### DIFF
--- a/builder-client/src/lib.rs
+++ b/builder-client/src/lib.rs
@@ -52,28 +52,28 @@ impl BuilderClient {
 
     pub async fn register_validators(
         &self,
-        registrations: Vec<SignedValidatorRegistrationData>,
+        registrations: &[SignedValidatorRegistrationData],
     ) -> Result<(), Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
             .map_err(|_| Error::InvalidUrl(self.base_url.clone()))?
             .extend(&["eth", "v1", "builder", "validators"]);
 
-        let response = self.client.post(url).json(&registrations).send().await?;
+        let response = self.client.post(url).json(registrations).send().await?;
 
         self.build_response(response).await
     }
 
     pub async fn submit_blinded_block<E: EthSpec>(
         &self,
-        block: SignedBlindedBeaconBlock<E>,
+        block: &SignedBlindedBeaconBlock<E>,
     ) -> Result<ExecutionPayload<E>, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
             .map_err(|_| Error::InvalidUrl(self.base_url.clone()))?
             .extend(&["eth", "v1", "builder", "blinded_blocks"]);
 
-        let response = self.client.post(url).json(&block).send().await?;
+        let response = self.client.post(url).json(block).send().await?;
 
         self.build_response(response).await
     }
@@ -82,7 +82,7 @@ impl BuilderClient {
         &self,
         slot: Slot,
         parent_hash: ExecutionBlockHash,
-        pubkey: PublicKeyBytes,
+        pubkey: &PublicKeyBytes,
     ) -> Result<SignedBuilderBid<E>, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -215,7 +215,7 @@ where
 }
 
 // Headers
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub enum ContentType {
     #[default]
     Json,
@@ -241,7 +241,7 @@ impl From<String> for ContentType {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub enum ContentEncoding {
     Gzip,
     #[default]

--- a/relay-api-types/src/lib.rs
+++ b/relay-api-types/src/lib.rs
@@ -24,12 +24,12 @@ pub struct SubmitBlockQueryParams {
 #[serde(bound = "E: EthSpec", untagged)]
 #[ssz(enum_behaviour = "transparent")]
 pub struct SubmitBlockRequest<E: EthSpec> {
-    message: BidTraceV1,
+    pub message: BidTraceV1,
     #[superstruct(flatten)]
-    execution_payload: ExecutionPayload<E>,
-    signature: Signature,
+    pub execution_payload: ExecutionPayload<E>,
+    pub signature: Signature,
     #[superstruct(only(Deneb))]
-    blobs_bundle: BlobsBundle<E>,
+    pub blobs_bundle: BlobsBundle<E>,
 }
 
 impl<E: EthSpec> ssz::Decode for SubmitBlockRequest<E> {
@@ -116,11 +116,11 @@ pub struct GetValidatorRegistrationQueryParams {
 #[serde(bound = "E: EthSpec", untagged)]
 #[ssz(enum_behaviour = "transparent")]
 pub struct HeaderSubmission<E: EthSpec> {
-    bid_trace: BidTraceV1,
+    pub bid_trace: BidTraceV1,
     #[superstruct(flatten)]
-    execution_payload_header: ExecutionPayloadHeader<E>,
+    pub execution_payload_header: ExecutionPayloadHeader<E>,
     #[superstruct(only(Deneb))]
-    blobs_bundle: BlobsBundle<E>,
+    pub blobs_bundle: BlobsBundle<E>,
 }
 
 #[superstruct(
@@ -137,8 +137,8 @@ pub struct HeaderSubmission<E: EthSpec> {
 #[ssz(enum_behaviour = "transparent")]
 pub struct SignedHeaderSubmission<E: EthSpec> {
     #[superstruct(flatten)]
-    message: HeaderSubmission<E>,
-    signature: Signature,
+    pub message: HeaderSubmission<E>,
+    pub signature: Signature,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]

--- a/relay-api-types/src/lib.rs
+++ b/relay-api-types/src/lib.rs
@@ -160,16 +160,16 @@ pub struct SignedCancellation {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TopBidUpdate {
     #[serde(with = "serde_utils::quoted_u64")]
-    timestamp: u64,
-    slot: Slot,
+    pub timestamp: u64,
+    pub slot: Slot,
     #[serde(with = "serde_utils::quoted_u64")]
-    block_number: u64,
-    block_hash: ExecutionBlockHash,
-    parent_hash: ExecutionBlockHash,
-    builder_pubkey: PublicKeyBytes,
-    fee_recipient: Address,
+    pub block_number: u64,
+    pub block_hash: ExecutionBlockHash,
+    pub parent_hash: ExecutionBlockHash,
+    pub builder_pubkey: PublicKeyBytes,
+    pub fee_recipient: Address,
     #[serde(with = "serde_utils::quoted_u256")]
-    value: Uint256,
+    pub value: Uint256,
 }
 
 // Builder API responses
@@ -182,8 +182,8 @@ pub enum Filtering {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorPreferences {
-    filtering: Filtering,
-    trusted_builders: Option<Vec<String>>,
+    pub filtering: Filtering,
+    pub trusted_builders: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/relay-api-types/src/lib.rs
+++ b/relay-api-types/src/lib.rs
@@ -233,6 +233,45 @@ pub struct BidTraceV2WithTimestamp {
     pub timestamp_ms: i64,
 }
 
+#[superstruct(
+    variants(Bellatrix, Capella, Deneb, Electra),
+    variant_attributes(
+        derive(Debug, Clone, Serialize, Deserialize, Encode, Decode),
+        serde(bound = "E: EthSpec", deny_unknown_fields),
+    ),
+    map_into(ExecutionPayloadHeader),
+    map_ref_into(ExecutionPayloadHeader)
+)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
+#[serde(bound = "E: EthSpec", untagged)]
+#[ssz(enum_behaviour = "transparent")]
+pub struct SignedHeaderResponse<E: EthSpec> {
+    #[superstruct(flatten)]
+    pub message: HeaderSubmission<E>,
+    pub signature: Signature,
+}
+
+#[superstruct(
+    variants(Bellatrix, Capella, Deneb, Electra),
+    variant_attributes(
+        derive(Debug, Clone, Serialize, Deserialize, Encode, Decode),
+        serde(bound = "E: EthSpec", deny_unknown_fields),
+    ),
+    map_into(ExecutionPayloadHeader),
+    map_ref_into(ExecutionPayloadHeader)
+)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
+#[serde(bound = "E: EthSpec", untagged)]
+#[ssz(enum_behaviour = "transparent")]
+pub struct HeaderResponse<E: EthSpec> {
+    #[superstruct(flatten)]
+    pub execution_payload_header: ExecutionPayloadHeader<E>,
+    #[superstruct(only(Deneb))]
+    pub blobs_bundle: BlobsBundle<E>,
+    pub value: Uint256,
+    pub pubkey: PublicKeyBytes,
+}
+
 // Builder API response types
 pub type GetValidatorsResponse = Vec<ValidatorsResponse>;
 

--- a/relay-api-types/src/lib.rs
+++ b/relay-api-types/src/lib.rs
@@ -247,7 +247,7 @@ pub struct BidTraceV2WithTimestamp {
 #[ssz(enum_behaviour = "transparent")]
 pub struct SignedHeaderResponse<E: EthSpec> {
     #[superstruct(flatten)]
-    pub message: HeaderSubmission<E>,
+    pub message: HeaderResponse<E>,
     pub signature: Signature,
 }
 

--- a/relay-client/src/lib.rs
+++ b/relay-client/src/lib.rs
@@ -102,8 +102,8 @@ impl RelayClient {
 
     pub async fn submit_block<E>(
         &self,
-        query_params: SubmitBlockQueryParams,
-        body: SubmitBlockRequest<E>,
+        query_params: &SubmitBlockQueryParams,
+        body: &SubmitBlockRequest<E>,
         content_type: ContentType,
         content_encoding: ContentEncoding,
     ) -> Result<(), Error>
@@ -117,8 +117,8 @@ impl RelayClient {
         let response = self
             .client
             .post(url)
-            .query(&query_params)
-            .json(&body)
+            .query(query_params)
+            .json(body)
             .send()
             .await?;
 
@@ -141,7 +141,7 @@ impl RelayClient {
 
     pub async fn get_delivered_payloads(
         &self,
-        query_params: GetDeliveredPayloadsQueryParams,
+        query_params: &GetDeliveredPayloadsQueryParams,
     ) -> Result<GetDeliveredPayloadsResponse, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
@@ -153,14 +153,14 @@ impl RelayClient {
                 "bidtraces",
                 "proposer_payload_delivered",
             ]);
-        let response = self.client.get(url).query(&query_params).send().await?;
+        let response = self.client.get(url).query(query_params).send().await?;
 
         self.build_response(response).await
     }
 
     pub async fn get_received_bids(
         &self,
-        query_params: GetReceivedBidsQueryParams,
+        query_params: &GetReceivedBidsQueryParams,
     ) -> Result<GetReceivedBidsResponse, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
@@ -172,28 +172,28 @@ impl RelayClient {
                 "bidtraces",
                 "builder_blocks_received",
             ]);
-        let response = self.client.get(url).query(&query_params).send().await?;
+        let response = self.client.get(url).query(query_params).send().await?;
 
         self.build_response(response).await
     }
 
     pub async fn get_validator_registration(
         &self,
-        query_params: GetValidatorRegistrationQueryParams,
+        query_params: &GetValidatorRegistrationQueryParams,
     ) -> Result<GetValidatorRegistrationResponse, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
             .map_err(|_| Error::InvalidUrl(self.base_url.clone()))?
             .extend(&["relay", "v1", "data", "validator_registration"]);
-        let response = self.client.get(url).query(&query_params).send().await?;
+        let response = self.client.get(url).query(query_params).send().await?;
 
         self.build_response(response).await
     }
 
     pub async fn submit_header<E>(
         &self,
-        query_params: SubmitBlockQueryParams,
-        body: SignedHeaderSubmission<E>,
+        query_params: &SubmitBlockQueryParams,
+        body: &SignedHeaderSubmission<E>,
         content_type: ContentType,
         content_encoding: ContentEncoding,
     ) -> Result<(), Error>
@@ -207,8 +207,8 @@ impl RelayClient {
         let response = self
             .client
             .post(url)
-            .query(&query_params)
-            .json(&body)
+            .query(query_params)
+            .json(body)
             .send()
             .await?;
 
@@ -218,8 +218,8 @@ impl RelayClient {
 
     pub async fn submit_block_optimistic_v2<E>(
         &self,
-        query_params: SubmitBlockQueryParams,
-        body: SubmitBlockRequest<E>,
+        query_params: &SubmitBlockQueryParams,
+        body: &SubmitBlockRequest<E>,
         content_type: ContentType,
         content_encoding: ContentEncoding,
     ) -> Result<(), Error>
@@ -233,8 +233,8 @@ impl RelayClient {
         let response = self
             .client
             .post(url)
-            .query(&query_params)
-            .json(&body)
+            .query(query_params)
+            .json(body)
             .send()
             .await?;
 
@@ -244,7 +244,7 @@ impl RelayClient {
 
     pub async fn submit_cancellation(
         &self,
-        body: SignedCancellation,
+        body: &SignedCancellation,
         content_type: ContentType,
         content_encoding: ContentEncoding,
     ) -> Result<(), Error> {
@@ -252,7 +252,7 @@ impl RelayClient {
         url.path_segments_mut()
             .map_err(|_| Error::InvalidUrl(self.base_url.clone()))?
             .extend(&["relay", "v1", "builder", "cancel_bid"]);
-        let response = self.client.post(url).json(&body).send().await?;
+        let response = self.client.post(url).json(body).send().await?;
 
         self.build_response_with_headers(response, content_type, content_encoding)
             .await


### PR DESCRIPTION
There's a few changes here:

- Avoid requiring ownership for some serialisable structs. The objects are just getting serialized, no need for ownership.
- Make some fields `pub` so they can be used.
- Add types for querying relays for the [best available header](https://ethereum.github.io/builder-specs/#/Builder/getHeader).