### PR TITLE
Implement builder ssz flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 bytes = "1.6"
-eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "1e84f6bd93fd626f3252c6e9ff1ed41edb39737d" }
+eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "3bc5f1f2a58b1df9454884672c8100fd5f79ba8b" }
 ethereum_serde_utils = "0.7"
 ethereum_ssz = "0.7"
 ethereum_ssz_derive = "0.7"
@@ -31,5 +31,5 @@ superstruct = "0.8"
 tokio = { version = "1", default-features = false, features = ["signal", "rt-multi-thread"] }
 tokio-tungstenite = "0.24.0"
 tracing = { version = "0.1", features = ["attributes"] }
-types = { git = "https://github.com/sigp/lighthouse.git", rev = "1e84f6bd93fd626f3252c6e9ff1ed41edb39737d" }
+types = { git = "https://github.com/sigp/lighthouse.git", rev = "3bc5f1f2a58b1df9454884672c8100fd5f79ba8b" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 async-trait = "0.1"
 axum = { version = "0.7", features = ["ws"] }
 bytes = "1.6"
-eth2 = { git = "https://github.com/eserilev/lighthouse.git", rev = "098d5b5270df3cc5564d573be42965b1e2f623db" }
+eth2 = { git = "https://github.com/eserilev/lighthouse.git", rev = "6e664dcddf610b4dd8dd59f56f7084d46bd91f74" }
 ethereum_serde_utils = "0.7"
 ethereum_ssz = "0.7"
 ethereum_ssz_derive = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 async-trait = "0.1"
 axum = { version = "0.7", features = ["ws"] }
 bytes = "1.6"
-eth2 = { git = "https://github.com/eserilev/lighthouse.git", rev = "6e664dcddf610b4dd8dd59f56f7084d46bd91f74" }
+eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "df131b2a6c58609d3f772cd1ac89487a0d4247d0" }
 ethereum_serde_utils = "0.7"
 ethereum_ssz = "0.7"
 ethereum_ssz_derive = "0.7"
@@ -30,5 +30,5 @@ superstruct = "0.8"
 tokio = { version = "1", default-features = false, features = ["signal", "rt-multi-thread"] }
 tokio-tungstenite = "0.24.0"
 tracing = { version = "0.1", features = ["attributes"] }
-types = { git = "https://github.com/sigp/lighthouse.git", rev = "c33307d70287fd3b7a70785f89dadcb737214903" }
+types = { git = "https://github.com/sigp/lighthouse.git", rev = "df131b2a6c58609d3f772cd1ac89487a0d4247d0" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ethereum_ssz_derive = "0.7"
 flate2 = "1.0"
 futures = "0.3.30"
 http = "1"
+mediatype = "0.19.13"
 reqwest = { version = "0.12.5", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 bytes = "1.6"
-eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "36effbb6e6c443332f9a9564c96ef36ee6ecc1d1" }
+eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "1e84f6bd93fd626f3252c6e9ff1ed41edb39737d" }
 ethereum_serde_utils = "0.7"
 ethereum_ssz = "0.7"
 ethereum_ssz_derive = "0.7"
@@ -31,5 +31,5 @@ superstruct = "0.8"
 tokio = { version = "1", default-features = false, features = ["signal", "rt-multi-thread"] }
 tokio-tungstenite = "0.24.0"
 tracing = { version = "0.1", features = ["attributes"] }
-types = { git = "https://github.com/sigp/lighthouse.git", rev = "36effbb6e6c443332f9a9564c96ef36ee6ecc1d1" }
+types = { git = "https://github.com/sigp/lighthouse.git", rev = "1e84f6bd93fd626f3252c6e9ff1ed41edb39737d" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,22 +14,22 @@ members = [
 
 [workspace.dependencies]
 async-trait = "0.1"
-axum = { version = "0.7", features = ["ws"] }
+axum = { version = "0.8", features = ["ws"] }
 bytes = "1.6"
-eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "df131b2a6c58609d3f772cd1ac89487a0d4247d0" }
+eth2 = { git = "https://github.com/sigp/lighthouse.git", rev = "36effbb6e6c443332f9a9564c96ef36ee6ecc1d1" }
 ethereum_serde_utils = "0.7"
 ethereum_ssz = "0.7"
 ethereum_ssz_derive = "0.7"
 flate2 = "1.0"
 futures = "0.3.30"
-http = "1"
+http = "1.2"
 mediatype = "0.19.13"
-reqwest = { version = "0.12.5", features = ["json"] }
+reqwest = { version = "0.12.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 superstruct = "0.8"
 tokio = { version = "1", default-features = false, features = ["signal", "rt-multi-thread"] }
 tokio-tungstenite = "0.24.0"
 tracing = { version = "0.1", features = ["attributes"] }
-types = { git = "https://github.com/sigp/lighthouse.git", rev = "df131b2a6c58609d3f772cd1ac89487a0d4247d0" }
+types = { git = "https://github.com/sigp/lighthouse.git", rev = "36effbb6e6c443332f9a9564c96ef36ee6ecc1d1" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ members = [
 async-trait = "0.1"
 axum = { version = "0.7", features = ["ws"] }
 bytes = "1.6"
-eth2 = { git = "https://github.com/realbigsean/lighthouse.git", rev = "10ce60633859ab4f20308ef42bb88e219e09fee5" }
-ethereum_serde_utils = "0.5.2"
-ethereum_ssz = "0.5.4"
-ethereum_ssz_derive = "0.5.4"
+eth2 = { git = "https://github.com/eserilev/lighthouse.git", rev = "098d5b5270df3cc5564d573be42965b1e2f623db" }
+ethereum_serde_utils = "0.7"
+ethereum_ssz = "0.7"
+ethereum_ssz_derive = "0.7"
 flate2 = "1.0"
 futures = "0.3.30"
 http = "1"

--- a/builder-client/Cargo.toml
+++ b/builder-client/Cargo.toml
@@ -9,3 +9,5 @@ ethereum-apis-common = { path = "../common" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+ethereum_ssz.workspace = true
+axum.workspace = true

--- a/builder-client/src/lib.rs
+++ b/builder-client/src/lib.rs
@@ -1,6 +1,6 @@
 use axum::http::HeaderMap;
 use axum::http::HeaderValue;
-pub use builder_api_types::*;
+use builder_api_types::*;
 pub use builder_bid::SignedBuilderBid;
 use ethereum_apis_common::ContentType;
 pub use ethereum_apis_common::ErrorResponse;

--- a/builder-client/src/lib.rs
+++ b/builder-client/src/lib.rs
@@ -1,14 +1,21 @@
+use axum::http::HeaderMap;
+use axum::http::HeaderValue;
 pub use builder_api_types::*;
 pub use builder_bid::SignedBuilderBid;
+use ethereum_apis_common::ContentType;
 pub use ethereum_apis_common::ErrorResponse;
+use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use reqwest::Url;
 use serde::de::DeserializeOwned;
+use ssz::DecodeError;
+use ssz::Encode;
 
 #[derive(Debug)]
 pub enum Error {
     Reqwest(reqwest::Error),
     InvalidJson(serde_json::Error, String),
+    InvalidSsz(DecodeError),
     ServerMessage(ErrorResponse),
     StatusCode(reqwest::StatusCode),
     InvalidUrl(Url),
@@ -31,6 +38,34 @@ impl BuilderClient {
         Self {
             client: Client::new(),
             base_url,
+        }
+    }
+
+    async fn build_response_with_headers<T>(
+        &self,
+        response: reqwest::Response,
+        content_type: ContentType,
+        fork_name: ForkName,
+    ) -> Result<T, Error>
+    where
+        T: DeserializeOwned + ForkVersionDecode,
+    {
+        let status = response.status();
+        let text = response.text().await?;
+
+        if status.is_success() {
+            match content_type {
+                ContentType::Json => {
+                    serde_json::from_str(&text).map_err(|e| Error::InvalidJson(e, text))
+                }
+                ContentType::Ssz => {
+                    T::from_ssz_bytes_by_fork(text.as_bytes(), fork_name).map_err(Error::InvalidSsz)
+                }
+            }
+        } else {
+            Err(Error::ServerMessage(
+                serde_json::from_str(&text).map_err(|e| Error::InvalidJson(e, text))?,
+            ))
         }
     }
 
@@ -67,15 +102,41 @@ impl BuilderClient {
     pub async fn submit_blinded_block<E: EthSpec>(
         &self,
         block: &SignedBlindedBeaconBlock<E>,
+        content_type: ContentType,
+        fork_name: ForkName,
     ) -> Result<ExecutionPayload<E>, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
             .map_err(|_| Error::InvalidUrl(self.base_url.clone()))?
             .extend(&["eth", "v1", "builder", "blinded_blocks"]);
 
-        let response = self.client.post(url).json(block).send().await?;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str(&content_type.to_string()).unwrap(),
+        );
 
-        self.build_response(response).await
+        let response = match content_type {
+            ContentType::Json => {
+                self.client
+                    .post(url)
+                    .headers(headers)
+                    .json(block)
+                    .send()
+                    .await?
+            }
+            ContentType::Ssz => {
+                self.client
+                    .post(url)
+                    .headers(headers)
+                    .body(block.as_ssz_bytes())
+                    .send()
+                    .await?
+            }
+        };
+
+        self.build_response_with_headers(response, content_type, fork_name)
+            .await
     }
 
     pub async fn get_header<E: EthSpec>(
@@ -83,6 +144,8 @@ impl BuilderClient {
         slot: Slot,
         parent_hash: ExecutionBlockHash,
         pubkey: &PublicKeyBytes,
+        content_type: ContentType,
+        fork_name: ForkName,
     ) -> Result<SignedBuilderBid<E>, Error> {
         let mut url = self.base_url.clone();
         url.path_segments_mut()
@@ -97,9 +160,16 @@ impl BuilderClient {
                 &pubkey.to_string(),
             ]);
 
-        let response = self.client.get(url).send().await?;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str(&content_type.to_string()).unwrap(),
+        );
 
-        self.build_response(response).await
+        let response = self.client.get(url).headers(headers).send().await?;
+
+        self.build_response_with_headers(response, content_type, fork_name)
+            .await
     }
 
     pub async fn get_status(&self) -> Result<(), Error> {

--- a/builder-client/src/lib.rs
+++ b/builder-client/src/lib.rs
@@ -4,7 +4,7 @@ pub use builder_api_types::*;
 pub use builder_bid::SignedBuilderBid;
 use ethereum_apis_common::ContentType;
 pub use ethereum_apis_common::ErrorResponse;
-use reqwest::header::CONTENT_TYPE;
+use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use reqwest::Client;
 use reqwest::Url;
 use serde::de::DeserializeOwned;
@@ -162,7 +162,7 @@ impl BuilderClient {
 
         let mut headers = HeaderMap::new();
         headers.insert(
-            CONTENT_TYPE,
+            ACCEPT,
             HeaderValue::from_str(&content_type.to_string()).unwrap(),
         );
 

--- a/builder-server/Cargo.toml
+++ b/builder-server/Cargo.toml
@@ -17,3 +17,6 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tower = "0.5.2"

--- a/builder-server/src/server.rs
+++ b/builder-server/src/server.rs
@@ -19,7 +19,6 @@ use http::{
     header::{ACCEPT, CONTENT_TYPE},
     HeaderMap,
 };
-use tracing::info;
 pub type ValidatorRegistrations<E> =
     VariableList<SignedValidatorRegistrationData, <E as EthSpec>::ValidatorRegistryLimit>;
 
@@ -106,21 +105,14 @@ where
         .and_then(|value| value.to_str().ok())
         .unwrap_or("application/json");
     let content_type = match Accept::from_str(content_type_str) {
-        Ok(Accept::Ssz) => {
-            info!("REQUESTED SSZ");
-            ContentType::Ssz
-        }
-        _ => {
-            info!("REQUESTED JSON");
-            ContentType::Json
-        }
+        Ok(Accept::Ssz) => ContentType::Ssz,
+        _ => ContentType::Json,
     };
 
     let res = api_impl
         .as_ref()
         .get_header(slot, parent_hash, pubkey)
         .await;
-    tracing::info!("Got response from builder, constructing response");
     build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot))
 }
 

--- a/builder-server/src/server.rs
+++ b/builder-server/src/server.rs
@@ -78,7 +78,12 @@ where
     let slot = block.slot();
     let res = api_impl.as_ref().submit_blinded_block(block).await;
 
-    build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot)).await
+    dbg!("in submit_blinded_block");
+    let response =
+        build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot))
+            .await;
+    dbg!(&response);
+    response
 }
 
 async fn get_status() -> StatusCode {
@@ -103,16 +108,17 @@ where
         Ok(Accept::Ssz) => {
             info!("REQUESTED SSZ");
             ContentType::Ssz
-        },
+        }
         _ => {
             info!("REQUESTED JSON");
             ContentType::Json
-        },
+        }
     };
 
     let res = api_impl
         .as_ref()
         .get_header(slot, parent_hash, pubkey)
         .await;
+    tracing::info!("Got response from builder, constructing response");
     build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot)).await
 }

--- a/builder-server/src/server.rs
+++ b/builder-server/src/server.rs
@@ -123,3 +123,287 @@ where
     tracing::info!("Got response from builder, constructing response");
     build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use axum::{body::Body, http::Request};
+    use builder_api_types::{
+        builder_bid::{BuilderBid, BuilderBidDeneb, SignedBuilderBid},
+        Address, BeaconBlock, BeaconBlockDeneb, Blob, BlobsBundle, EmptyBlock, ExecutionPayload,
+        ExecutionPayloadAndBlobs, ExecutionPayloadDeneb, ForkName, ForkVersionDecode,
+        ForkVersionedResponse, FullPayloadContents, KzgCommitment, KzgProof, MainnetEthSpec,
+        Signature, Uint256, ValidatorRegistrationData,
+    };
+    use ethereum_apis_common::{ErrorResponse, CONSENSUS_VERSION_HEADER};
+    use http::{HeaderValue, Response};
+    use ssz::Encode;
+    use std::{marker::PhantomData, usize};
+    use tower::ServiceExt;
+
+    pub const PREFERENCE_ACCEPT_VALUE: &str =
+        "application/octet-stream;q=1.0,application/json;q=0.9";
+
+    #[derive(Clone)]
+    struct DummyBuilder<E: EthSpec> {
+        _phantom: PhantomData<E>,
+    }
+
+    impl<E: EthSpec> AsRef<DummyBuilder<E>> for DummyBuilder<E> {
+        fn as_ref(&self) -> &DummyBuilder<E> {
+            self
+        }
+    }
+
+    #[async_trait]
+    impl<E: EthSpec> Builder<E> for DummyBuilder<E> {
+        fn fork_name_at_slot(&self, _slot: Slot) -> builder_api_types::ForkName {
+            ForkName::Deneb
+        }
+
+        async fn get_header(
+            &self,
+            _slot: Slot,
+            _parent_hash: ExecutionBlockHash,
+            _pubkey: PublicKeyBytes,
+        ) -> Result<SignedBuilderBid<E>, ErrorResponse> {
+            Ok(SignedBuilderBid {
+                message: BuilderBid::Deneb(BuilderBidDeneb {
+                    value: Uint256::from(42),
+                    pubkey: PublicKeyBytes::empty(),
+                    blob_kzg_commitments: vec![KzgCommitment::empty_for_testing(); 5].into(),
+                    header: Default::default(),
+                }),
+                signature: Signature::empty(),
+            })
+        }
+
+        async fn register_validators(
+            &self,
+            _registrations: Vec<SignedValidatorRegistrationData>,
+        ) -> Result<(), ErrorResponse> {
+            Ok(())
+        }
+
+        async fn submit_blinded_block(
+            &self,
+            _block: SignedBlindedBeaconBlock<E>,
+        ) -> Result<FullPayloadContents<E>, ErrorResponse> {
+            let payload_and_blobs: ExecutionPayloadAndBlobs<E> = ExecutionPayloadAndBlobs {
+                blobs_bundle: BlobsBundle {
+                    commitments: vec![KzgCommitment::empty_for_testing()].into(),
+                    proofs: vec![KzgProof::empty()].into(),
+                    blobs: vec![Blob::<E>::new(vec![42; E::bytes_per_blob()]).unwrap()].into(),
+                },
+                execution_payload: ExecutionPayload::Deneb(ExecutionPayloadDeneb::default()),
+            };
+            let full_payload = FullPayloadContents::PayloadAndBlobs(payload_and_blobs);
+            Ok(full_payload)
+        }
+    }
+
+    async fn send_request_and_assert_response(
+        request: http::request::Request<Body>,
+        expected_status: StatusCode,
+        check_headers: impl AsyncFn(Response<Body>),
+    ) {
+        let app = new(DummyBuilder::<MainnetEthSpec> {
+            _phantom: PhantomData,
+        });
+
+        let response = app.oneshot(request).await.unwrap();
+        // Assert status code
+        assert_eq!(response.status(), expected_status);
+        // Check headers
+        check_headers(response).await;
+    }
+
+    #[tokio::test]
+    async fn test_registration() {
+        let dummy_registration: ValidatorRegistrations<MainnetEthSpec> = VariableList::from(vec![
+            SignedValidatorRegistrationData {
+                message: ValidatorRegistrationData {
+                    fee_recipient: Address::random(),
+                    gas_limit: 100000,
+                    timestamp: 19939149139,
+                    pubkey: PublicKeyBytes::empty(),
+                },
+                signature: Signature::empty()
+            };
+            100
+        ]);
+
+        // Test ssz request
+        send_request_and_assert_response(
+            Request::builder()
+                .uri("/eth/v1/builder/validators")
+                .method("POST")
+                .header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                )
+                .body(Body::from(dummy_registration.as_ssz_bytes()))
+                .unwrap(),
+            StatusCode::OK,
+            async |_| {},
+        )
+        .await;
+
+        // Test json request
+        send_request_and_assert_response(
+            Request::builder()
+                .uri("/eth/v1/builder/validators")
+                .method("POST")
+                .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+                .body(Body::from(serde_json::to_vec(&dummy_registration).unwrap()))
+                .unwrap(),
+            StatusCode::OK,
+            async |_| {},
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_get_header() {
+        // Test ssz request
+        send_request_and_assert_response(
+            Request::builder()
+                .uri(format!(
+                    "/eth/v1/builder/header/{}/{}/{}",
+                    Slot::new(42),
+                    "0x379b447308533668e5323f45b7d5232259f508e8d61ff5b945c9b016792cd94c",
+                    "0xafda62054797148859d1f277ad04e8129bc767c10dae0e2d116f03b87fe9c2a36093a93eab75b4b5bfd3fd0d48816396"
+                ))
+                .method("GET")
+                .header(
+                    ACCEPT,
+                    HeaderValue::from_static("application/octet-stream"),
+                ).body(Body::empty())
+                .unwrap(),
+            StatusCode::OK,
+            async |response| {
+                let headers = response.headers();
+                assert_eq!(headers.get(CONTENT_TYPE).unwrap(), HeaderValue::from_str(&ContentType::Ssz.to_string()).unwrap());
+                assert_eq!(headers.get(ethereum_apis_common::CONSENSUS_VERSION_HEADER).unwrap(), HeaderValue::from_str(&ForkName::Deneb.to_string()).unwrap());
+            }
+        )
+        .await;
+
+        // Test json request
+        send_request_and_assert_response(
+            Request::builder()
+                .uri(format!(
+                    "/eth/v1/builder/header/{}/{}/{}",
+                    Slot::new(42),
+                    "0x379b447308533668e5323f45b7d5232259f508e8d61ff5b945c9b016792cd94c",
+                    "0xafda62054797148859d1f277ad04e8129bc767c10dae0e2d116f03b87fe9c2a36093a93eab75b4b5bfd3fd0d48816396"
+                ))
+                .method("GET")
+                .header(
+                    ACCEPT,
+                    HeaderValue::from_static("application/json"),
+                ).body(Body::empty())
+                .unwrap(),
+            StatusCode::OK,
+            async |response| {
+                let headers = response.headers();
+                assert_eq!(headers.get(CONTENT_TYPE).unwrap(), HeaderValue::from_str(&ContentType::Json.to_string()).unwrap());
+                assert_eq!(headers.get(ethereum_apis_common::CONSENSUS_VERSION_HEADER).unwrap(), HeaderValue::from_str(&ForkName::Deneb.to_string()).unwrap());
+            }
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_submit_blinded_beacon_block() {
+        let spec = MainnetEthSpec::default_spec();
+        let dummy_block = SignedBlindedBeaconBlock::<MainnetEthSpec>::from_block(
+            BeaconBlock::Deneb(BeaconBlockDeneb::empty(&spec)),
+            Signature::empty(),
+        );
+        // Test ssz request
+        send_request_and_assert_response(
+            Request::builder()
+                .uri("/eth/v1/builder/blinded_blocks")
+                .method("POST")
+                .header(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                )
+                .header(ACCEPT, HeaderValue::from_static(&PREFERENCE_ACCEPT_VALUE))
+                .header(
+                    CONSENSUS_VERSION_HEADER,
+                    HeaderValue::from_str(&ForkName::Deneb.to_string()).unwrap(),
+                )
+                .body(Body::from(dummy_block.as_ssz_bytes()))
+                .unwrap(),
+            StatusCode::OK,
+            async |response: Response<Body>| {
+                let headers = response.headers();
+                assert_eq!(
+                    headers.get(CONTENT_TYPE).unwrap(),
+                    HeaderValue::from_str(&ContentType::Ssz.to_string()).unwrap()
+                );
+                assert_eq!(
+                    headers
+                        .get(ethereum_apis_common::CONSENSUS_VERSION_HEADER)
+                        .unwrap(),
+                    HeaderValue::from_str(&ForkName::Deneb.to_string()).unwrap()
+                );
+
+                // Get response body as bytes
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("should get bytes response");
+                assert!(
+                    FullPayloadContents::<MainnetEthSpec>::from_ssz_bytes_by_fork(
+                        &body,
+                        ForkName::Deneb
+                    )
+                    .is_ok()
+                );
+            },
+        )
+        .await;
+
+        // Test json request
+        send_request_and_assert_response(
+            Request::builder()
+                .uri("/eth/v1/builder/blinded_blocks")
+                .method("POST")
+                .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+                .header(ACCEPT, HeaderValue::from_static("application/json"))
+                .header(
+                    CONSENSUS_VERSION_HEADER,
+                    HeaderValue::from_str(&ForkName::Deneb.to_string()).unwrap(),
+                )
+                .body(Body::from(serde_json::to_vec(&dummy_block).unwrap()))
+                .unwrap(),
+            StatusCode::OK,
+            async |response: Response<Body>| {
+                let headers = response.headers();
+                assert_eq!(
+                    headers.get(CONTENT_TYPE).unwrap(),
+                    HeaderValue::from_str(&ContentType::Json.to_string()).unwrap()
+                );
+                assert_eq!(
+                    headers
+                        .get(ethereum_apis_common::CONSENSUS_VERSION_HEADER)
+                        .unwrap(),
+                    HeaderValue::from_str(&ForkName::Deneb.to_string()).unwrap()
+                );
+
+                // Get response body as bytes
+                let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("should get bytes response");
+                assert!(serde_json::from_slice::<
+                    ForkVersionedResponse<FullPayloadContents::<MainnetEthSpec>>,
+                >(&body)
+                .is_ok());
+            },
+        )
+        .await;
+    }
+}

--- a/builder-server/src/server.rs
+++ b/builder-server/src/server.rs
@@ -6,7 +6,7 @@ use axum::{
     http::StatusCode,
     response::Response,
     routing::{get, post},
-    Json, Router,
+    Router,
 };
 use builder_api_types::{
     EthSpec, ExecutionBlockHash, PublicKeyBytes, SignedBlindedBeaconBlock,
@@ -20,7 +20,7 @@ use http::{
     HeaderMap,
 };
 use tracing::info;
-pub type ValidatorRegistrations<E: EthSpec> =
+pub type ValidatorRegistrations<E> =
     VariableList<SignedValidatorRegistrationData, <E as EthSpec>::ValidatorRegistryLimit>;
 
 use crate::builder::Builder;
@@ -50,7 +50,7 @@ where
 
 async fn register_validators<I, A, E>(
     State(api_impl): State<I>,
-    JsonOrSsz(registrations): JsonOrSsz<Vec<SignedValidatorRegistrationData>>,
+    JsonOrSsz(registrations): JsonOrSsz<ValidatorRegistrations<E>>,
 ) -> Result<Response<Body>, StatusCode>
 where
     E: EthSpec,

--- a/builder-server/src/server.rs
+++ b/builder-server/src/server.rs
@@ -9,8 +9,7 @@ use axum::{
     Json, Router,
 };
 use builder_api_types::{
-    eth_spec::EthSpec, fork_versioned_response::ForkVersionDecode, ExecutionBlockHash, ForkName,
-    FullPayloadContents, MainnetEthSpec, PublicKeyBytes, SignedBlindedBeaconBlock,
+    EthSpec, ExecutionBlockHash, PublicKeyBytes, SignedBlindedBeaconBlock,
     SignedValidatorRegistrationData, Slot,
 };
 use ethereum_apis_common::{
@@ -57,7 +56,7 @@ where
     A: Builder<E>,
 {
     let res = api_impl.as_ref().register_validators(registrations).await;
-    build_response(res).await
+    build_response(res)
 }
 
 async fn submit_blinded_block<I, A, E>(
@@ -70,7 +69,6 @@ where
     I: AsRef<A> + Send + Sync,
     A: Builder<E>,
 {
-    dbg!(&headers);
     let content_type_header = headers.get(CONTENT_TYPE);
     let content_type = content_type_header.and_then(|value| value.to_str().ok());
     let content_type = match content_type {
@@ -81,12 +79,7 @@ where
 
     let res = api_impl.as_ref().submit_blinded_block(block).await;
 
-    println!("in submit_blinded_block");
-    let response =
-        build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot))
-            .await;
-    println!("Got response ok {}", response.is_ok());
-    response
+    build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot))
 }
 
 async fn get_status() -> StatusCode {
@@ -123,112 +116,5 @@ where
         .get_header(slot, parent_hash, pubkey)
         .await;
     tracing::info!("Got response from builder, constructing response");
-    build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot)).await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use async_trait::async_trait;
-    use axum::{body::Body, http::Request};
-    use builder_api_types::{
-        builder_bid::SignedBuilderBid, BeaconBlock, BeaconBlockDeneb, Blob, BlobsBundle,
-        EmptyBlock, ExecutionPayload, ExecutionPayloadAndBlobs, ExecutionPayloadDeneb, ForkName,
-        ForkVersionDecode, FullPayloadContents, KzgCommitment, KzgProof, MainnetEthSpec, Signature,
-    };
-    use ethereum_apis_common::{ErrorResponse, CONSENSUS_VERSION_HEADER};
-    use http::HeaderValue;
-    use ssz::Encode;
-    use std::{marker::PhantomData, usize};
-    use tower::ServiceExt;
-
-    #[derive(Clone)]
-    struct DummyBuilder<E: EthSpec> {
-        _phantom: PhantomData<E>,
-    }
-
-    impl<E: EthSpec> AsRef<DummyBuilder<E>> for DummyBuilder<E> {
-        fn as_ref(&self) -> &DummyBuilder<E> {
-            self
-        }
-    }
-
-    #[async_trait]
-    impl<E: EthSpec> Builder<E> for DummyBuilder<E> {
-        fn fork_name_at_slot(&self, _slot: Slot) -> builder_api_types::ForkName {
-            ForkName::Deneb
-        }
-
-        async fn get_header(
-            &self,
-            _slot: Slot,
-            _parent_hash: ExecutionBlockHash,
-            _pubkey: PublicKeyBytes,
-        ) -> Result<SignedBuilderBid<E>, ErrorResponse> {
-            todo!()
-        }
-
-        async fn register_validators(
-            &self,
-            _registrations: Vec<SignedValidatorRegistrationData>,
-        ) -> Result<(), ErrorResponse> {
-            Ok(())
-        }
-
-        async fn submit_blinded_block(
-            &self,
-            _block: SignedBlindedBeaconBlock<E>,
-        ) -> Result<FullPayloadContents<E>, ErrorResponse> {
-            let payload_and_blobs: ExecutionPayloadAndBlobs<E> = ExecutionPayloadAndBlobs {
-                blobs_bundle: BlobsBundle {
-                    commitments: vec![KzgCommitment::empty_for_testing()].into(),
-                    proofs: vec![KzgProof::empty()].into(),
-                    blobs: vec![Blob::<E>::new(vec![42; E::bytes_per_blob()]).unwrap()].into(),
-                },
-                execution_payload: ExecutionPayload::Deneb(ExecutionPayloadDeneb {
-                    ..Default::default()
-                }),
-            };
-            let full_payload = FullPayloadContents::PayloadAndBlobs(payload_and_blobs);
-            Ok(full_payload)
-        }
-    }
-
-    #[tokio::test]
-    async fn test_api() {
-        let app = new(DummyBuilder::<MainnetEthSpec> {
-            _phantom: PhantomData,
-        });
-
-        let spec = MainnetEthSpec::default_spec();
-        let dummy_block = SignedBlindedBeaconBlock::<MainnetEthSpec>::from_block(
-            BeaconBlock::Deneb(BeaconBlockDeneb::empty(&spec)),
-            Signature::empty(),
-        );
-        let request = Request::builder()
-            .uri("/eth/v1/builder/blinded_blocks")
-            .method("POST")
-            .header(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/octet-stream"),
-            )
-            .header(CONSENSUS_VERSION_HEADER, HeaderValue::from_static("deneb"))
-            .body(Body::from(dummy_block.as_ssz_bytes()))
-            .unwrap();
-
-        let response = app.oneshot(request).await.unwrap();
-
-        // Assert status code
-        // assert_eq!(response.status(), StatusCode::ACCEPTED);
-
-        // Get response body as bytes
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-
-        dbg!(
-            FullPayloadContents::<MainnetEthSpec>::from_ssz_bytes_by_fork(&body, ForkName::Deneb)
-                .unwrap()
-        );
-    }
+    build_response_with_headers(res, content_type, api_impl.as_ref().fork_name_at_slot(slot))
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,6 +14,5 @@ http.workspace = true
 mediatype.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
 tracing.workspace = true
 beacon-api-types = { path = "../beacon-api-types" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,6 +11,7 @@ ethereum_ssz.workspace = true
 flate2.workspace = true
 futures.workspace = true
 http.workspace = true
+mediatype.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/relay-server/src/server.rs
+++ b/relay-server/src/server.rs
@@ -71,7 +71,7 @@ where
     A: Builder<E>,
 {
     let result = api_impl.as_ref().submit_block(query_params, body).await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// SubmitBlockOptimisticV2 - POST /relay/v1/builder/blocks_optimistic_v2
@@ -90,7 +90,7 @@ where
         .as_ref()
         .submit_block_optimistic_v2(query_params, body)
         .await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// SubmitHeader - POST /relay/v1/builder/headers
@@ -106,7 +106,7 @@ where
     A: Builder<E>,
 {
     let result = api_impl.as_ref().submit_header(query_params, body).await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// SubmitCancellation - POST /relay/v1/builder/cancel_bid
@@ -121,7 +121,7 @@ where
     A: Builder<E>,
 {
     let result = api_impl.as_ref().submit_cancellation(body).await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// GetValidators - GET /relay/v1/builder/validators
@@ -133,7 +133,7 @@ where
     E: EthSpec,
 {
     let result = api_impl.as_ref().get_validators().await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// GetTopBids - GET /relay/v1/builder/top_bids
@@ -173,7 +173,7 @@ where
         while let Some(update) = stream.next().await {
             match serde_json::to_string(&update) {
                 Ok(json) => {
-                    if let Err(e) = sender.send(Message::Text(json)).await {
+                    if let Err(e) = sender.send(Message::text(json)).await {
                         tracing::error!("Error sending message: {:?}", e);
                         break;
                     }
@@ -213,7 +213,7 @@ where
     A: Data,
 {
     let result = api_impl.as_ref().get_delivered_payloads(query_params).await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// GetReceivedBids - GET /relay/v1/data/bidtraces/builder_blocks_received
@@ -227,7 +227,7 @@ where
     A: Data,
 {
     let result = api_impl.as_ref().get_received_bids(query_params).await;
-    build_response(result).await
+    build_response(result)
 }
 
 /// GetValidatorRegistration - GET /relay/v1/data/validator_registration
@@ -244,5 +244,5 @@ where
         .as_ref()
         .get_validator_registration(query_params)
         .await;
-    build_response(result).await
+    build_response(result)
 }

--- a/relay-server/src/server.rs
+++ b/relay-server/src/server.rs
@@ -189,9 +189,8 @@ where
 
     let mut recv_task = tokio::spawn(async move {
         while let Some(Ok(message)) = receiver.next().await {
-            match message {
-                Message::Close(_) => break,
-                _ => {}
+            if let Message::Close(_) = message {
+                break;
             }
         }
     });


### PR DESCRIPTION
Spec: https://github.com/ethereum/builder-specs/pull/104

- I've introduced a new trait `ForkVersionDecode` in LH. It was required so I could create the relevant axum extractor.
- Added a new `JsonOrSszWithFork` extractor which can extract request body data that impls `DeserializeOwned` + `ForkVersionDecode`. 
- Added SSZ functionality to both the builder api client and server 
- Added a new common fn `build_response_with_headers`
   - appends content type & consensus version headers to the resopnse
   - in the JSON case, creates a `ForkVersionedResponse` & serializes to JSON
   - in the SSZ case, encodes to SSZ